### PR TITLE
Added possibility to override styles

### DIFF
--- a/components/Close.js
+++ b/components/Close.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
-export const Close = ({ onPress }) => {
+export const Close = ({ onPress, rootStyle, iconStyle }) => {
 	return (
-		<TouchableOpacity activeOpacity={1} onPress={onPress} style={CloseStyles.closeButton}>
-			<View style={[ CloseStyles.iconLine, { transform: [ { rotateZ: '45deg' } ] } ]} />
-			<View style={[ CloseStyles.iconLine, { transform: [ { rotateZ: '135deg' } ] } ]} />
+		<TouchableOpacity activeOpacity={1} onPress={onPress} style={[CloseStyles.closeButton, rootStyle]}>
+			<View style={[ CloseStyles.iconLine, iconStyle, { transform: [ { rotateZ: '45deg' } ] } ]} />
+			<View style={[ CloseStyles.iconLine, iconStyle, { transform: [ { rotateZ: '135deg' } ] } ]} />
 		</TouchableOpacity>
 	);
 };

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import { StyleSheet, ScrollView, TouchableHighlight, Animated, Dimensions, PanResponder, Easing } from 'react-native';
 import { Bar } from './Bar';
 import { Close } from './Close';
@@ -9,33 +9,20 @@ const FULL_HEIGHT = Dimensions.get('window').height;
 const FULL_WIDTH = Dimensions.get('window').width;
 const CONTAINER_HEIGHT = FULL_HEIGHT - 100;
 
-export default class SwipeablePanel extends React.Component {
-	static propTypes = {
-		isActive: PropTypes.bool.isRequired,
-		onClose: PropTypes.func,
-		fullWidth: PropTypes.bool,
-		onPressCloseButton: PropTypes.func,
-		noBackgroundOpacity: PropTypes.bool,
-		containerStyle: PropTypes.object,
-		closeRootStyle: PropTypes.object,
-		closeIconStyle: PropTypes.object,
-	};
+const STATUS = {
+	CLOSED: 0,
+	SMALL: 1,
+	LARGE: 2,
+};
 
-	static defaultProps = {
-		containerStyle: {},
-		onClose: () => {},
-		fullWidth: true,
-		closeRootStyle: {},
-		closeIconStyle: {},
-	};
-
+class SwipeablePanel extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
 			showComponent: false,
 			opacity: new Animated.Value(0),
 			canScroll: false,
-			status: 0 // {0: close, 1: small, 2: large}
+			status: STATUS.CLOSED,
 		};
 		this.pan = new Animated.ValueXY({ x: 0, y: FULL_HEIGHT });
 		this.oldPan = { x: 0, y: 0 };
@@ -43,41 +30,63 @@ export default class SwipeablePanel extends React.Component {
 		this._panResponder = PanResponder.create({
 			onStartShouldSetPanResponder: (evt, gestureState) => true,
 			onPanResponderGrant: (evt, gestureState) => {
-				if (this.state.status == 1) this.pan.setOffset({ x: this.pan.x._value, y: FULL_HEIGHT - 400 });
-				else if (this.state.status == 2) this.pan.setOffset({ x: this.pan.x._value, y: 0 });
+				const {status} = this.state;
+
+				if (status === STATUS.SMALL) {
+					this.pan.setOffset({ x: this.pan.x._value, y: FULL_HEIGHT - 400 });
+				}	else if (status === STATUS.LARGE) {
+					this.pan.setOffset({ x: this.pan.x._value, y: 0 });
+				}
+
 				this.pan.setValue({ x: 0, y: 0 });
 			},
 			onPanResponderMove: (evt, gestureState) => {
 				const currentTop = this.pan.y._offset + gestureState.dy;
-				if (currentTop > 0) this.pan.setValue({ x: 0, y: gestureState.dy });
+				if (currentTop > 0) {
+					this.pan.setValue({ x: 0, y: gestureState.dy });
+				}
 			},
 			onPanResponderRelease: (evt, { vx, vy }) => {
 				this.pan.flattenOffset();
 
 				const distance = this.oldPan.y - this.pan.y._value;
 				const absDistance = Math.abs(distance);
+				const {status} = this.state;
 
-				if (this.state.status == 2) {
-					if (0 < absDistance && absDistance < 100) this._animateToLargePanel();
-					else if (100 < absDistance && absDistance < CONTAINER_HEIGHT - 200) this._animateToSmallPanel();
-					else if (CONTAINER_HEIGHT - 200 < absDistance) this._animateClosingAndOnCloseProp();
+				if (status === STATUS.LARGE) {
+					if (0 < absDistance && absDistance < 100) {
+						this._animateToLargePanel();
+					} else if (100 < absDistance && absDistance < CONTAINER_HEIGHT - 200) {
+						this._animateToSmallPanel();
+					} else if (CONTAINER_HEIGHT - 200 < absDistance) {
+						this._animateClosingAndOnCloseProp();
+					}
 				} else {
-					if (distance < -100) this._animateClosingAndOnCloseProp(false);
-					else if (distance > 0 && distance > 50) this._animateToLargePanel();
-					else this._animateToSmallPanel();
+					if (distance < -100) {
+						this._animateClosingAndOnCloseProp(false);
+					} else if (distance > 0 && distance > 50) {
+						this._animateToLargePanel();
+					} else {
+						this._animateToSmallPanel();
+					}
 				}
 			}
 		});
 	}
 
-	componentDidMount = () => {};
-
 	componentDidUpdate(prevProps, prevState) {
-		if (prevProps.isActive != this.props.isActive) {
-			if (this.props.isActive) {
-				if (this.props.openLarge) this.openLarge();
-				else this.openDetails();
-			} else this.closeDetails(true);
+		const {isActive, openLarge} = this.props;
+
+		if (prevProps.isActive !== isActive) {
+			if (isActive) {
+				if (openLarge) {
+					this.openLarge();
+				} else {
+					this.openDetails();
+				}
+			} else {
+				this.closeDetails(true);
+			}
 		}
 	}
 
@@ -87,18 +96,18 @@ export default class SwipeablePanel extends React.Component {
 
 	_animateToLargePanel = () => {
 		this._animateSpringPan(0, 0, 200);
-		this.setState({ canScroll: true, status: 2 });
+		this.setState({ canScroll: true, status: STATUS.LARGE });
 		this.oldPan = { x: 0, y: 0 };
 	};
 
 	_animateToSmallPanel = () => {
 		this._animateSpringPan(0, FULL_HEIGHT - 400, 300);
-		this.setState({ status: 1 });
+		this.setState({ status: STATUS.SMALL });
 		this.oldPan = { x: 0, y: FULL_HEIGHT - 400 };
 	};
 
 	openLarge = () => {
-		this.setState({ showComponent: true, status: 2, canScroll: true });
+		this.setState({ showComponent: true, status: STATUS.LARGE, canScroll: true });
 		Animated.parallel([
 			this._animateTimingPan(),
 			this._animateTimingOpacity(1, 300),
@@ -107,7 +116,7 @@ export default class SwipeablePanel extends React.Component {
 	};
 
 	openDetails = () => {
-		this.setState({ showComponent: true, status: 1 });
+		this.setState({ showComponent: true, status: STATUS.SMALL });
 		Animated.parallel([
 			this._animateTimingPan(0, FULL_HEIGHT - 400),
 			this._animateTimingOpacity(1, 300),
@@ -117,18 +126,18 @@ export default class SwipeablePanel extends React.Component {
 
 	closeDetails = (isCloseButtonPress) => {
 		const {status} = this.state;
-		const duration = status === 2 ? 500 : 300;
+		const duration = status === STATUS.LARGE ? 500 : 300;
 		const easing = isCloseButtonPress ? Easing.bezier(0.98, -0.11, 0.44, 0.59) : Easing.linear;
 
 		Animated.parallel([
 			this._animateTimingPan(0, FULL_HEIGHT, duration, easing),
-			this._animateTimingOpacity(status === 1 ? 0 : 1, status === 2 ? 500 : 300),
+			this._animateTimingOpacity(status === STATUS.SMALL ? 0 : 1, status === STATUS.LARGE ? 500 : 300),
 		]);
 
 		setTimeout(() => {
-			this.setState({ showComponent: false, canScroll: false, status: 0 });
+			this.setState({ showComponent: false, canScroll: false, status: STATUS.CLOSED });
 			this.props.onClose();
-		}, status === 2 ? 450 : 250);
+		}, status === STATUS.LARGE ? 450 : 250);
 	};
 
 	onPressCloseButton = () => {
@@ -199,6 +208,25 @@ export default class SwipeablePanel extends React.Component {
 	}
 }
 
+SwipeablePanel.propTypes = {
+	isActive: PropTypes.bool.isRequired,
+	onClose: PropTypes.func,
+	fullWidth: PropTypes.bool,
+	onPressCloseButton: PropTypes.func,
+	noBackgroundOpacity: PropTypes.bool,
+	containerStyle: PropTypes.object,
+	closeRootStyle: PropTypes.object,
+	closeIconStyle: PropTypes.object,
+};
+
+SwipeablePanel.defaultProps = {
+	containerStyle: {},
+	onClose: () => {},
+	fullWidth: true,
+	closeRootStyle: {},
+	closeIconStyle: {},
+};
+
 const SwipeablePanelStyles = StyleSheet.create({
 	background: {
 		position: 'absolute',
@@ -232,3 +260,5 @@ const SwipeablePanelStyles = StyleSheet.create({
 		width: '100%',
 	},
 });
+
+export default SwipeablePanel;

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -163,39 +163,34 @@ export default class SwipeablePanel extends React.Component {
 	};
 
 	render() {
-		const { showComponent, opacity, canScroll, children } = this.state;
-		const { noBackgroundOpacity, containerStyle,onPressCloseButton, fullWidth, closeRootStyle, closeIconStyle } = this.props;
-
-		const backgroundColor = noBackgroundOpacity ? 'rgba(0,0,0,0)' : 'rgba(0,0,0,0.5)';
+		const { showComponent, opacity } = this.state;
+		const { noBackgroundOpacity, containerStyle, closeRootStyle, closeIconStyle } = this.props;
 
 		return showComponent ? (
 			<Animated.View
 				style={[
 					SwipeablePanelStyles.background,
-					{ opacity, backgroundColor }
+					{ opacity, backgroundColor: noBackgroundOpacity ? 'rgba(0,0,0,0)' : 'rgba(0,0,0,0.5)' }
 				]}
 			>
 				<Animated.View
 					style={[
 						SwipeablePanelStyles.container,
-						{ width: fullWidth ? FULL_WIDTH : FULL_WIDTH - 50 },
+						{ width: this.props.fullWidth ? FULL_WIDTH : FULL_WIDTH - 50 },
 						{ transform: this.pan.getTranslateTransform() },
 						containerStyle,
 					]}
 					{...this._panResponder.panHandlers}
 				>
 					<Bar />
-					{
-						onPressCloseButton &&
-						<Close rootStyle={closeRootStyle} iconStyle={closeIconStyle} onPress={this.onPressCloseButton} />
-					}
-					<ScrollView contentContainerStyle={SwipeablePanelStyles.scrollViewContentContainerStyle}>
-						{canScroll ? (
+					{this.props.onPressCloseButton && <Close rootStyle={closeRootStyle} iconStyle={closeIconStyle} onPress={this.onPressCloseButton} />}
+					<ScrollView contentContainerStyle={{ width: '100%' }}>
+						{this.state.canScroll ? (
 							<TouchableHighlight>
-								<React.Fragment>{children}</React.Fragment>
+								<React.Fragment>{this.props.children}</React.Fragment>
 							</TouchableHighlight>
 						) : (
-							children
+							this.props.children
 						)}
 					</ScrollView>
 				</Animated.View>

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -52,12 +52,17 @@ class SwipeablePanel extends Component {
 				const distance = this.oldPan.y - this.pan.y._value;
 				const absDistance = Math.abs(distance);
 				const {status} = this.state;
+				const {onlyLarge} = this.props;
 
 				if (status === STATUS.LARGE) {
 					if (0 < absDistance && absDistance < 100) {
 						this._animateToLargePanel();
 					} else if (100 < absDistance && absDistance < CONTAINER_HEIGHT - 200) {
-						this._animateToSmallPanel();
+						if (onlyLarge) {
+							this._animateClosingAndOnCloseProp(true);
+						} else {
+							this._animateToSmallPanel();
+						}
 					} else if (CONTAINER_HEIGHT - 200 < absDistance) {
 						this._animateClosingAndOnCloseProp();
 					}
@@ -75,11 +80,11 @@ class SwipeablePanel extends Component {
 	}
 
 	componentDidUpdate(prevProps, prevState) {
-		const {isActive, openLarge} = this.props;
+		const {isActive, openLarge, onlyLarge} = this.props;
 
 		if (prevProps.isActive !== isActive) {
 			if (isActive) {
-				if (openLarge) {
+				if (openLarge || onlyLarge) {
 					this.openLarge();
 				} else {
 					this.openDetails();
@@ -217,6 +222,8 @@ SwipeablePanel.propTypes = {
 	style: PropTypes.object,
 	closeRootStyle: PropTypes.object,
 	closeIconStyle: PropTypes.object,
+	openLarge: PropTypes.bool,
+	onlyLarge: PropTypes.bool,
 };
 
 SwipeablePanel.defaultProps = {
@@ -225,6 +232,8 @@ SwipeablePanel.defaultProps = {
 	fullWidth: true,
 	closeRootStyle: {},
 	closeIconStyle: {},
+	openLarge: false,
+	onlyLarge: false,
 };
 
 const SwipeablePanelStyles = StyleSheet.create({

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -198,7 +198,7 @@ class SwipeablePanel extends Component {
 				>
 					<Bar />
 					{this.props.onPressCloseButton && <Close rootStyle={closeRootStyle} iconStyle={closeIconStyle} onPress={this.onPressCloseButton} />}
-					<ScrollView contentContainerStyle={{ width: '100%' }}>
+					<ScrollView contentContainerStyle={SwipeablePanelStyles.scrollViewContentContainerStyle}>
 						{this.state.canScroll ? (
 							<TouchableHighlight>
 								<React.Fragment>{this.props.children}</React.Fragment>

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -173,7 +173,7 @@ class SwipeablePanel extends Component {
 
 	render() {
 		const { showComponent, opacity } = this.state;
-		const { noBackgroundOpacity, containerStyle, closeRootStyle, closeIconStyle } = this.props;
+		const { noBackgroundOpacity, style, closeRootStyle, closeIconStyle } = this.props;
 
 		return showComponent ? (
 			<Animated.View
@@ -187,7 +187,7 @@ class SwipeablePanel extends Component {
 						SwipeablePanelStyles.container,
 						{ width: this.props.fullWidth ? FULL_WIDTH : FULL_WIDTH - 50 },
 						{ transform: this.pan.getTranslateTransform() },
-						containerStyle,
+						style,
 					]}
 					{...this._panResponder.panHandlers}
 				>
@@ -214,13 +214,13 @@ SwipeablePanel.propTypes = {
 	fullWidth: PropTypes.bool,
 	onPressCloseButton: PropTypes.func,
 	noBackgroundOpacity: PropTypes.bool,
-	containerStyle: PropTypes.object,
+	style: PropTypes.object,
 	closeRootStyle: PropTypes.object,
 	closeIconStyle: PropTypes.object,
 };
 
 SwipeablePanel.defaultProps = {
-	containerStyle: {},
+	style: {},
 	onClose: () => {},
 	fullWidth: true,
 	closeRootStyle: {},

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -15,7 +15,12 @@ export default class SwipeablePanel extends React.Component {
 		onClose: PropTypes.func,
 		fullWidth: PropTypes.bool,
 		onPressCloseButton: PropTypes.func,
-		noBackgroundOpacity: PropTypes.bool
+		noBackgroundOpacity: PropTypes.bool,
+		containerStyle: PropTypes.object,
+	};
+
+	static defaultProps = {
+		containerStyle: {},
 	};
 
 	constructor(props) {
@@ -162,7 +167,7 @@ export default class SwipeablePanel extends React.Component {
 
 	render() {
 		const { showComponent, opacity } = this.state;
-		const { noBackgroundOpacity } = this.props;
+		const { noBackgroundOpacity, containerStyle } = this.props;
 
 		return showComponent ? (
 			<Animated.View
@@ -175,7 +180,8 @@ export default class SwipeablePanel extends React.Component {
 					style={[
 						SwipeablePanelStyles.container,
 						{ width: this.props.fullWidth ? FULL_WIDTH : FULL_WIDTH - 50 },
-						{ transform: this.pan.getTranslateTransform() }
+						{ transform: this.pan.getTranslateTransform() },
+						containerStyle,
 					]}
 					{...this._panResponder.panHandlers}
 				>


### PR DESCRIPTION
Added optional possibility to override styles for:
- panel
- close button

Added optional possibility to use only 2 states: **large** and **closed**, without middle **small** state.

Small code styling.

----------------------------------------------------

Would be great if you accept this PR and I will use your lib directly instead of my fork!

Here is an example how it looks like in our app:

![image](https://user-images.githubusercontent.com/8337018/67942630-4d0a8e80-fbe9-11e9-9b5d-9ef4dd09fdc9.png)
