### PR TITLE
Added a possibility to touch outside of the bottom sheet

### DIFF
--- a/components/Panel.js
+++ b/components/Panel.js
@@ -274,6 +274,7 @@ const SwipeablePanelStyles = StyleSheet.create({
   background: {
     position: "absolute",
     zIndex: 1,
+    bottom: 0,
     justifyContent: "center",
     alignItems: "center",
     width: FULL_WIDTH,

--- a/components/Panel.js
+++ b/components/Panel.js
@@ -162,6 +162,7 @@ class SwipeablePanel extends Component {
   render() {
     const { showComponent } = this.state;
     const {
+      allowTouchOutside,
       noBackgroundOpacity,
       style,
       closeRootStyle,
@@ -177,6 +178,9 @@ class SwipeablePanel extends Component {
             backgroundColor: noBackgroundOpacity
               ? "rgba(0,0,0,0)"
               : "rgba(0,0,0,0.5)",
+          },
+          {
+            height: allowTouchOutside ? 'auto' : FULL_HEIGHT,
           },
         ]}
       >
@@ -242,6 +246,7 @@ SwipeablePanel.propTypes = {
   closeRootStyle: PropTypes.object,
   closeIconStyle: PropTypes.object,
   closeOnTouchOutside: PropTypes.bool,
+  allowTouchOutside: PropTypes.bool,
   onlyLarge: PropTypes.bool,
   onlySmall: PropTypes.bool,
   openLarge: PropTypes.bool,
@@ -261,6 +266,7 @@ SwipeablePanel.defaultProps = {
   showCloseButton: false,
   noBar: false,
   closeOnTouchOutside: false,
+  allowTouchOutside: false,
   barStyle: {},
 };
 
@@ -271,7 +277,6 @@ const SwipeablePanelStyles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     width: FULL_WIDTH,
-    height: FULL_HEIGHT,
     backgroundColor: "rgba(0,0,0,0.5)",
   },
   panel: {


### PR DESCRIPTION
Hello there!

Sometimes it's useful to show the bottom sheet and at the same time to allow click outside of it.

For instance, you have a map, and two markers and clicking on one of them is going to pop up the bottom sheet and show a piece of information. 
And then you want to touch the second one and see other information, but without hiding the bottom sheet. 😉