### PR TITLE
Small gap at bottom when modal is Full screen

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -96,7 +96,7 @@ class SwipeablePanel extends React.Component<SwipeablePanelProps, SwipeablePanel
         )
           this.state.pan.setValue({
             x: 0,
-            y: gestureState.dy,
+            y: Math.max(0, gestureState.dy),
           });
       },
       onPanResponderRelease: (evt, gestureState) => {


### PR DESCRIPTION
when panel is full open it was capturing negative value events which results in a small gap at bottom, see screenshot.
![IMG_1311](https://user-images.githubusercontent.com/23050213/93427099-df3b8400-f8da-11ea-9d87-5747cb4bc403.png)
